### PR TITLE
Configuere checksum & homebrew tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.crypto.checksum.Checksum
+
 plugins {
     id "distribution"
     id "com.github.johnrengelman.shadow" version "5.2.0"
@@ -66,7 +68,7 @@ test {
     useJUnitPlatform()
 }
 
-task createChecksum(type: org.gradle.crypto.checksum.Checksum) {
+task createChecksum(type: Checksum) {
     dependsOn(assembleDist)
     files = distZip.outputs.files
     outputDir = distZip.destinationDir

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,3 @@
-import org.apache.tools.ant.filters.*
-import org.gradle.crypto.checksum.Checksum
-
 plugins {
     id "distribution"
     id "com.github.johnrengelman.shadow" version "5.2.0"
@@ -13,7 +10,6 @@ plugins {
 repositories {
     jcenter()
 }
-
 
 dependencies {
     implementation 'com.offbytwo:docopt:0.6.0.20150202'
@@ -34,7 +30,6 @@ dependencies {
     testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine:5.5.2')
     testImplementation "com.github.stefanbirkner:system-rules:1.17.2"
 }
-
 
 distributions {
     main {
@@ -71,27 +66,27 @@ test {
     useJUnitPlatform()
 }
 
-task createChecksum(type: Checksum) {
+task createChecksum(type: org.gradle.crypto.checksum.Checksum) {
+    dependsOn(assembleDist)
     files = distZip.outputs.files
-    outputDir = distZip.outputs.files[0].getParentFile()
+    outputDir = distZip.destinationDir
     algorithm = Checksum.Algorithm.SHA256
 }
 
-/**
 task homebrew(type: Copy) {
-    project.afterEvaluate {
-            println(createChecksum.outputs.files[0])
-            from('src/main/scripts/jbang.rb')
-            into(buildDir.toString() + '/brew/formula')
-            filter(ReplaceTokens,
-                    tokens: [
-                            'projectVersion': project.version,
-                            'sha256'        : new File(distZip.outputs.files[0].path + ".sha256").text
-                    ]
-            )
-        }
+    dependsOn(createChecksum)
+    inputs.property('version', project.version)
+    from('src/main/scripts/jbang.rb')
+    into(buildDir.toString() + '/brew/formula')
+	doFirst { t ->
+	    t.filter(org.apache.tools.ant.filters.ReplaceTokens,
+            tokens: [
+                projectVersion: project.version,
+                sha256        : new File(distZip.archiveFile.asFile.get().absolutePath + '.sha256').text
+            ]
+	    )
+	}
 }
-**/
 
 githubRelease {
     // currently does not work as project.version not set.
@@ -119,10 +114,6 @@ versioner {
     }
 }
 
-
-createChecksum.dependsOn(assembleDist)
-//homebrew.dependsOn(createChecksum,distZip)
-//build.dependsOn(homebrew)
-build.dependsOn(createChecksum)
+build.dependsOn(homebrew)
 group = "dk.xam.jbang"
 sourceCompatibility = '11'


### PR DESCRIPTION
This PR has the following updates
- simplify the `createChecksum` task by
  - using FQN for its task type
  - adding explicit dependsOn in task configuration
  - using `distZip.destinationDir` as `outputDir`
- simplify `homebrew` task by
  - adding explicit dependsOn in task configuration
  - define an input.property on the project's version (reduces up-to-date misses)
  - delay read of sha256 file until the very last moment, once filename has been written