### PR TITLE
Webdriver example enhancements

### DIFF
--- a/examples/webdriver.java
+++ b/examples/webdriver.java
@@ -1,6 +1,7 @@
 //usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.github.bonigarcia:webdrivermanager:3.8.1
 //DEPS org.seleniumhq.selenium:selenium-java:3.141.59
+//DEPS org.slf4j:slf4j-simple:1.7.30
 
 import static java.awt.Toolkit.getDefaultToolkit;
 import static javax.imageio.ImageIO.write;
@@ -9,6 +10,7 @@ import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.util.concurrent.TimeUnit;
 
 import org.openqa.selenium.*;
 import org.openqa.selenium.chrome.*;
@@ -27,8 +29,10 @@ public class webdriver {
     options.addArguments("--disable-dev-shm-usage");
     options.addArguments("--disable-browser-side-navigation"); 
     options.addArguments("--disable-gpu");
-    options.setPageLoadStrategy(PageLoadStrategy.NONE); 
-    return new ChromeDriver(options); 
+    options.setPageLoadStrategy(PageLoadStrategy.NONE);
+    WebDriver driver = new ChromeDriver(options);
+    driver.manage().timeouts().implicitlyWait(10, TimeUnit.SECONDS);
+    return driver;
   }
 
   public static void takeScreenShot() throws Exception {


### PR DESCRIPTION
Added slf4j-simple. Used to have better output from WebDriverManager.
Added webdriver implicitlyWait 10 sec. Used to make sure that html elements rendered in time and
      avoid nosuchelementexception. See https://stackoverflow.com/questions/47337738/exception-in-thread-main-org-openqa-selenium-nosuchelementexception-no-such-e.

Tested on OSX. Java 8.
With the original example I have.
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Starting ChromeDriver 80.0.3987.106 (f68069574609230cf9b635cd784cfb1bf81bb53a-refs/branch-heads/3987@{#882}) on port 25974
Only local connections are allowed.
Please protect ports used by ChromeDriver and related test frameworks to prevent access by malicious code.
бер. 03, 2020 6:06:50 PM org.openqa.selenium.remote.ProtocolHandshake createSession
INFO: Detected dialect: W3C
Exception in thread "main" org.openqa.selenium.NoSuchElementException: no such element: Unable to locate element: {"method":"css selector","selector":"*[name='q']"}
  (Session info: chrome=80.0.3987.122)
For documentation on this error, please visit: https://www.seleniumhq.org/exceptions/no_such_element.html
Build info: version: '3.141.59', revision: 'e82be7d358', time: '2018-11-14T08:17:03'
System info: host: 'MacBook-Pro', ip: 'fe80:0:0:0:c4c:1632:a2e8:81cb%en0', os.name: 'Mac OS X', os.arch: 'x86_64', os.version: '10.15.3', java.version: '1.8.0_242'
Driver info: org.openqa.selenium.chrome.ChromeDriver
Capabilities {acceptInsecureCerts: false, browserName: chrome, browserVersion: 80.0.3987.122, chrome: {chromedriverVersion: 80.0.3987.106 (f68069574609..., userDataDir: /var/folders/hk/k5q8q9f95lb...}, goog:chromeOptions: {debuggerAddress: localhost:49954}, javascriptEnabled: true, networkConnectionEnabled: false, pageLoadStrategy: none, platform: MAC, platformName: MAC, proxy: Proxy(), setWindowRect: true, strictFileInteractability: false, timeouts: {implicit: 0, pageLoad: 300000, script: 30000}, unhandledPromptBehavior: dismiss and notify}
Session ID: e90571f5ec5fc4f7d4aa3e04bdd262ad
*** Element info: {Using=name, value=q}
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.openqa.selenium.remote.http.W3CHttpResponseCodec.createException(W3CHttpResponseCodec.java:187)
	at org.openqa.selenium.remote.http.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:122)
	at org.openqa.selenium.remote.http.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:49)
	at org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:158)
	at org.openqa.selenium.remote.service.DriverCommandExecutor.execute(DriverCommandExecutor.java:83)
	at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:552)
	at org.openqa.selenium.remote.RemoteWebDriver.findElement(RemoteWebDriver.java:323)
	at org.openqa.selenium.remote.RemoteWebDriver.findElementByName(RemoteWebDriver.java:404)
	at org.openqa.selenium.By$ByName.findElement(By.java:284)
	at org.openqa.selenium.remote.RemoteWebDriver.findElement(RemoteWebDriver.java:315)
	at webdriver.googleIt(webdriver.java:44)
	at webdriver.main(webdriver.java:53)
```
After 
```
[jbang] Resolving dependencies...
[jbang]     Resolving io.github.bonigarcia:webdrivermanager:3.8.1...Done
[jbang]     Resolving org.seleniumhq.selenium:selenium-java:3.141.59...Done
[jbang]     Resolving org.slf4j:slf4j-simple:1.7.30...Done
[jbang] Dependencies resolved
[jbang] Building jar...
[main] INFO io.github.bonigarcia.wdm.WebDriverManager - Using chromedriver 80.0.3987.106 (since Google Chrome 80 is installed in your machine)
[main] INFO io.github.bonigarcia.wdm.WebDriverManager - Exporting webdriver.chrome.driver as /Users/skabashn/.m2/repository/webdriver/chromedriver/mac64/80.0.3987.106/chromedriver
Starting ChromeDriver 80.0.3987.106 (f68069574609230cf9b635cd784cfb1bf81bb53a-refs/branch-heads/3987@{#882}) on port 13535
Only local connections are allowed.
Please protect ports used by ChromeDriver and related test frameworks to prevent access by malicious code.
бер. 03, 2020 7:16:36 PM org.openqa.selenium.remote.ProtocolHandshake createSession
INFO: Detected dialect: W3C
```
