### PR TITLE
Minor change in the way the smee example stays running

### DIFF
--- a/examples/smee.java
+++ b/examples/smee.java
@@ -96,11 +96,9 @@ class smee implements Callable<Integer> {
             log.info("Connected " + url);
         }
 
-        while(true) {
-            Thread.sleep(50000);
-        }
+        Thread.currentThread().join();
 
-        //return 0;
+        return 0;
     }
 
     private void onError(Throwable error) {


### PR DESCRIPTION
It's a really minor change and not important at all but
I just think it's a cleaner way of waiting around than
writing an endless loop with waits.