### PR TITLE
Adding jitpack support

### DIFF
--- a/examples/urldep.java
+++ b/examples/urldep.java
@@ -1,0 +1,19 @@
+//usr/bin/env jbang "$0" "$@" ; exit $?
+
+//DEPS https://github.com/kohsuke/github-api/tree/github-api-1.107
+
+import static java.lang.System.out;
+import static java.util.Arrays.*;
+import org.kohsuke.github.*;
+
+class githubinfo {
+
+    public static void main(String[] args) throws Exception {
+
+        GitHub github = GitHub.connectAnonymously();
+
+        GHRepository ghRepo = github.getRepository("maxandersen/jbang");
+
+        out.println(ghRepo);
+    }
+}

--- a/readme.adoc
+++ b/readme.adoc
@@ -399,6 +399,9 @@ For ease of use there are also a few shorthands to use popular commonly availabl
 
 |`google`
 |`https://maven.google.com/`
+
+|`jitpack`
+|`https://jitpack.io/`
 |===
 
 Following example enables use of Maven Central and add a custom `acme` repository.

--- a/readme.adoc
+++ b/readme.adoc
@@ -329,7 +329,7 @@ Using `jbang --init=cli helloworld.java` you get a more complete Hello World CLI
 == Declare dependencies
 
 If you want to write real scripts you will want to use some java libraries.
-To specify dependencies you use gradle-style locators. Below are examples for `log4j`.
+To specify dependencies you use gradle-style locators or links to Git sources. Below are examples for `log4j`.
 
 === Using `//DEPS`
 
@@ -374,15 +374,52 @@ $ ./classpath_example.java
 1 [main] INFO classpath_example  - Hello from Java!
 ----
 
-==== Offline mode
+=== Using links to Git sources
+
+Instead of gradle-style locators you can also use URLs to projects on GitHub, GitLab or BitBucket.
+Links to those projects will then be converted to references to artifacts on https://jitpack.io/[jitpack].
+You can use links to the root of the project, to the root of a tag/release and to specific commits.
+
+If the project you link to has multiple modules and you want only a specific module you can specify the
+name of the module by appending `#name-of-module` to the URL.
+
+And finally if the link you provide is to a specific branch of the project then you need to append
+`#:SNAPSHOT` to the URL. (If you have both a branch and a module name then use `#name-of-module:SNAPSHOT`)
+
+Examples of links and their resulting locator:
+
+|===
+|Link | Locator
+|https://github.com/maxandersen/jbang
+|com.github.maxandersen:jbang:master-SNAPSHOT
+
+|https://github.com/maxandersen/jbang/tree/v1.2.3
+|com.github.maxandersen:jbang:v1.2.3
+
+|https://github.com/maxandersen/jbang/tree/f1f34b031d2163e0cdc6f9a3725b59f47129c923[https://github.com/maxandersen/jbang/tree/f1f34b031...]
+|com.github.maxandersen:jbang:f1f34b031d
+
+|https://github.com/maxandersen/jbang#mymodule
+|com.github.maxandersen.jbang:mymodule:master-SNAPSHOT
+
+|https://github.com/maxandersen/jbang/tree/mybranch#:SNAPSHOT
+|com.github.maxandersen:jbang:mybranch-SNAPSHOT
+
+|https://github.com/maxandersen/jbang/tree/mybranch#mymodule:SNAPSHOT
+|com.github.maxandersen.jbang.mymodule:mybranch-SNAPSHOT
+|===
+
+=== Offline mode
 
 In case you prefer `jbang` to just fail-fast when dependencies cannot be found locally you can run `jbang` in offline mode using
 `jbang -o` or `jbang --offline`. In this mode `jbang` will simply fail if dependencies have not already been cached already.
 
 === Repositories
 
-By default `jbang` uses jcenter[https://jcenter.bintray.com/] as its repository as it is a superset of Maven Central
+By default `jbang` uses https://jcenter.bintray.com/[jcenter] as its repository as it is a superset of Maven Central
 and supposedly should be faster.
+
+And if you are using the above mentioned URL dependencies https://jitpack.io[jitpack] will be added automatically as well.
 
 If that is not sufficient for you or need some custom repo you can use `//REPOS id=repourl` to
 state which repository URL to use.

--- a/src/main/java/dk/xam/jbang/DependencyUtil.java
+++ b/src/main/java/dk/xam/jbang/DependencyUtil.java
@@ -235,6 +235,8 @@ class DependencyUtil {
 					resolver.withMavenCentralRepo(true);
 				}
 			};
+		} else if ("jitpack".equalsIgnoreCase(reporef)) {
+			return new MavenRepo(Optional.ofNullable(repoid).orElse("jitpack"), "https://jitpack.io/");
 		} else {
 			return new MavenRepo(repoid, reporef);
 		}

--- a/src/main/java/dk/xam/jbang/JitPackUtil.java
+++ b/src/main/java/dk/xam/jbang/JitPackUtil.java
@@ -1,0 +1,166 @@
+package dk.xam.jbang;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+public class JitPackUtil {
+	private static final Pattern GITHUB_TREE_PATTERN = Pattern.compile(
+			"^https?://github.com/(.+?)/(.+?)(/tree/(.+?)(/(.+?))?)?/?$");
+	private static final Pattern GITUB_COMMIT_PATTERN = Pattern.compile(
+			"^https?://github.com/(.+?)/(.+?)/commit/(.+)$");
+	private static final Pattern GITLAB_TREE_PATTERN = Pattern.compile(
+			"^https?://gitlab.com/(.+?)/(.+?)(/-/tree/(.+?)(/(.+?))?)?/?$");
+	private static final Pattern GITLAB_COMMIT_PATTERN = Pattern.compile(
+			"^https?://gitlab.com/(.+?)/(.+?)/-/commit/(.+)$");
+	private static final Pattern BITBUCKET_TREE_PATTERN = Pattern.compile(
+			"^https?://bitbucket.org/(.+?)/(.+?)(/src/(.+?)(/(.+?))?)?/?$");
+	private static final Pattern BITBUCKET_COMMIT_PATTERN = Pattern.compile(
+			"^https?://bitbucket.org/(.+?)/(.+?)/commits/(.+)$");
+
+	private static final Pattern POSSIBLE_SHA1_PATTERN = Pattern.compile("^[0-9a-f]{40}$");
+
+	public static String ensureGAV(String ref) {
+		try {
+			// If the reference is a URL we'll try to convert it to a proper GAV
+			URL url = new URL(ref);
+			if (url.getProtocol().equals("https") || url.getProtocol().equals("http")) {
+				// Strip and save the #part of the URL
+				final String actualRef;
+				String hash = url.getRef();
+				if (hash != null) {
+					actualRef = ref.substring(0, ref.lastIndexOf('#'));
+				} else {
+					actualRef = ref;
+				}
+
+				// Extract GAV coordinates from hte URL
+				// NB: Ordering of the list below is important!
+				Optional<Pgamv> coords = Stream	.<Function<String, Pgamv>>of(
+						JitPackUtil::githubCommitUrlToGAV,
+						JitPackUtil::githubTreeUrlToGAV,
+						JitPackUtil::gitlabCommitUrlToGAV,
+						JitPackUtil::gitlabTreeUrlToGAV,
+						JitPackUtil::bitbucketCommitUrlToGAV,
+						JitPackUtil::bitbucketTreeUrlToGAV)
+												.map(f -> f.apply(actualRef))
+												.filter(Objects::nonNull)
+												.findFirst();
+
+				if (coords.isPresent()) {
+					if (hash != null) {
+						String[] parts = hash.split(":");
+						String module = parts[0];
+						String snapshot = (parts.length == 2) ? parts[1] : null;
+
+						// Override GAV coords with values from the #part of the URL
+						Pgamv pgamv = coords.get().module(module);
+						if (snapshot != null && pgamv.version != null) {
+							pgamv = pgamv.version(pgamv.version + "-SNAPSHOT");
+						}
+						ref = pgamv.toGav();
+					} else {
+						ref = coords.get().toGav();
+					}
+				}
+			}
+		} catch (MalformedURLException ex) {
+			// Ignore exception and just return the ref as-is
+		}
+		return ref;
+	}
+
+	static class Pgamv {
+		final String provider;
+		final String groupId;
+		final String artifactId;
+		final String module;
+		final String version;
+
+		Pgamv(String provider, String groupId, String artifactId, String module, String version) {
+			this.provider = provider;
+			this.groupId = groupId;
+			this.artifactId = artifactId;
+			this.module = module;
+			this.version = version;
+		}
+
+		Pgamv module(String module) {
+			return new Pgamv(provider, groupId, artifactId, module, version);
+		}
+
+		Pgamv version(String version) {
+			return new Pgamv(provider, groupId, artifactId, module, version);
+		}
+
+		String toGav() {
+			String v;
+			if (version == null || version.equals("master")) {
+				v = "master-SNAPSHOT";
+			} else if (POSSIBLE_SHA1_PATTERN.matcher(version).matches()) {
+				v = version.substring(0, 10);
+			} else {
+				v = version;
+			}
+			if (module != null) {
+				return provider + "." + groupId + "." + artifactId + ":" + module + ":" + v;
+			} else {
+				return provider + "." + groupId + ":" + artifactId + ":" + v;
+			}
+		}
+	}
+
+	static Pgamv githubTreeUrlToGAV(String ref) {
+		Matcher m = GITHUB_TREE_PATTERN.matcher(ref);
+		if (m.matches()) {
+			return new Pgamv("com.github", m.group(1), m.group(2), m.group(6), m.group(4));
+		}
+		return null;
+	}
+
+	static Pgamv githubCommitUrlToGAV(String ref) {
+		Matcher m = GITUB_COMMIT_PATTERN.matcher(ref);
+		if (m.matches()) {
+			return new Pgamv("com.github", m.group(1), m.group(2), null, m.group(3));
+		}
+		return null;
+	}
+
+	static Pgamv gitlabTreeUrlToGAV(String ref) {
+		Matcher m = GITLAB_TREE_PATTERN.matcher(ref);
+		if (m.matches()) {
+			return new Pgamv("com.gitlab", m.group(1), m.group(2), m.group(6), m.group(4));
+		}
+		return null;
+	}
+
+	static Pgamv gitlabCommitUrlToGAV(String ref) {
+		Matcher m = GITLAB_COMMIT_PATTERN.matcher(ref);
+		if (m.matches()) {
+			return new Pgamv("com.gitlab", m.group(1), m.group(2), null, m.group(3));
+		}
+		return null;
+	}
+
+	static Pgamv bitbucketTreeUrlToGAV(String ref) {
+		Matcher m = BITBUCKET_TREE_PATTERN.matcher(ref);
+		if (m.matches()) {
+			return new Pgamv("org.bitbucket", m.group(1), m.group(2), m.group(6), m.group(4));
+		}
+		return null;
+	}
+
+	static Pgamv bitbucketCommitUrlToGAV(String ref) {
+		Matcher m = BITBUCKET_COMMIT_PATTERN.matcher(ref);
+		if (m.matches()) {
+			return new Pgamv("org.bitbucket", m.group(1), m.group(2), null, m.group(3));
+		}
+		return null;
+	}
+
+}

--- a/src/test/java/dk/xam/jbang/DependencyResolverTest.java
+++ b/src/test/java/dk/xam/jbang/DependencyResolverTest.java
@@ -1,5 +1,6 @@
 package dk.xam.jbang;
 
+import static dk.xam.jbang.DependencyUtil.toMavenRepo;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
@@ -102,7 +103,8 @@ class DependencyResolverTest {
 
 		List<String> deps = Arrays.asList("com.offbytwo:docopt:0.6.0.20150202", "log4j:log4j:1.2+");
 
-		List<File> artifacts = dr.resolveDependenciesViaAether(deps, Collections.emptyList(), false, true);
+		List<File> artifacts = dr.resolveDependenciesViaAether(deps, Arrays.asList(toMavenRepo("jcenter")), false,
+				true);
 
 		assertEquals(2, artifacts.size());
 

--- a/src/test/java/dk/xam/jbang/TestJitPack.java
+++ b/src/test/java/dk/xam/jbang/TestJitPack.java
@@ -1,0 +1,132 @@
+package dk.xam.jbang;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class TestJitPack {
+
+	@Test
+	void testExtractGithubUrlDependencies() {
+		assertEquals(JitPackUtil.ensureGAV("https://github.com/maxandersen/jbang"),
+				"com.github.maxandersen:jbang:master-SNAPSHOT");
+
+		assertEquals(JitPackUtil.ensureGAV("https://github.com/maxandersen/jbang/tree/master"),
+				"com.github.maxandersen:jbang:master-SNAPSHOT");
+
+		assertEquals(JitPackUtil.ensureGAV("https://github.com/maxandersen/jbang/tree/master/foo"),
+				"com.github.maxandersen.jbang:foo:master-SNAPSHOT");
+
+		assertEquals(JitPackUtil.ensureGAV("https://github.com/maxandersen/jbang/tree/v0.20.0"),
+				"com.github.maxandersen:jbang:v0.20.0");
+
+		assertEquals(
+				JitPackUtil.ensureGAV(
+						"https://github.com/maxandersen/jbang/commit/90dfcbf354fc0838f08eea0680bf736b7c069b4e"),
+				"com.github.maxandersen:jbang:90dfcbf354");
+
+	}
+
+	@Test
+	void testExtractGithubUrlWithHashDependencies() {
+		assertEquals(JitPackUtil.ensureGAV("https://github.com/maxandersen/jbang#foo"),
+				"com.github.maxandersen.jbang:foo:master-SNAPSHOT");
+
+		assertEquals(JitPackUtil.ensureGAV("https://github.com/maxandersen/jbang/tree/master#foo"),
+				"com.github.maxandersen.jbang:foo:master-SNAPSHOT");
+
+		assertEquals(JitPackUtil.ensureGAV("https://github.com/maxandersen/jbang/tree/master/foo#bar"),
+				"com.github.maxandersen.jbang:bar:master-SNAPSHOT");
+
+		assertEquals(JitPackUtil.ensureGAV("https://github.com/maxandersen/jbang/tree/somebranch#foo:SNAPSHOT"),
+				"com.github.maxandersen.jbang:foo:somebranch-SNAPSHOT");
+
+		assertEquals(
+				JitPackUtil.ensureGAV(
+						"https://github.com/maxandersen/jbang/commit/90dfcbf354fc0838f08eea0680bf736b7c069b4e#foo"),
+				"com.github.maxandersen.jbang:foo:90dfcbf354");
+
+	}
+
+	@Test
+	void testExtractGitlabUrlDependencies() {
+		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab"),
+				"com.gitlab.gitlab-org:gitlab:master-SNAPSHOT");
+
+		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab/-/tree/master"),
+				"com.gitlab.gitlab-org:gitlab:master-SNAPSHOT");
+
+		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab/-/tree/master/foo"),
+				"com.gitlab.gitlab-org.gitlab:foo:master-SNAPSHOT");
+
+		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab/-/tree/v12.7.9-ee"),
+				"com.gitlab.gitlab-org:gitlab:v12.7.9-ee");
+
+		assertEquals(
+				JitPackUtil.ensureGAV(
+						"https://gitlab.com/gitlab-org/gitlab/-/commit/120262d85822e6a3d4e04f5c84d0075c60309d97"),
+				"com.gitlab.gitlab-org:gitlab:120262d858");
+
+	}
+
+	@Test
+	void testExtractGitlabUrlWithHashDependencies() {
+		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab#foo"),
+				"com.gitlab.gitlab-org.gitlab:foo:master-SNAPSHOT");
+
+		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab/-/tree/master#foo"),
+				"com.gitlab.gitlab-org.gitlab:foo:master-SNAPSHOT");
+
+		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab/-/tree/master/foo#bar"),
+				"com.gitlab.gitlab-org.gitlab:bar:master-SNAPSHOT");
+
+		assertEquals(JitPackUtil.ensureGAV("https://gitlab.com/gitlab-org/gitlab/-/tree/somebranch#foo:SNAPSHOT"),
+				"com.gitlab.gitlab-org.gitlab:foo:somebranch-SNAPSHOT");
+
+		assertEquals(
+				JitPackUtil.ensureGAV(
+						"https://gitlab.com/gitlab-org/gitlab/-/commit/120262d85822e6a3d4e04f5c84d0075c60309d97#foo"),
+				"com.gitlab.gitlab-org.gitlab:foo:120262d858");
+
+	}
+
+	@Test
+	void testExtractBitbucketUrlDependencies() {
+		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler"),
+				"org.bitbucket.ceylon:ceylon-compiler:master-SNAPSHOT");
+
+		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler/src/master/"),
+				"org.bitbucket.ceylon:ceylon-compiler:master-SNAPSHOT");
+
+		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler/src/master/foo/"),
+				"org.bitbucket.ceylon.ceylon-compiler:foo:master-SNAPSHOT");
+
+		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler/src/0.4/"),
+				"org.bitbucket.ceylon:ceylon-compiler:0.4");
+
+		assertEquals(JitPackUtil.ensureGAV(
+				"https://bitbucket.org/ceylon/ceylon-compiler/commits/9a5e4667af5ae03e036dff1294b81b653be6dffc"),
+				"org.bitbucket.ceylon:ceylon-compiler:9a5e4667af");
+
+	}
+
+	@Test
+	void testExtractBitbucketUrlWithHashDependencies() {
+		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler#foo"),
+				"org.bitbucket.ceylon.ceylon-compiler:foo:master-SNAPSHOT");
+
+		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler/src/master/#foo"),
+				"org.bitbucket.ceylon.ceylon-compiler:foo:master-SNAPSHOT");
+
+		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler/src/master/foo/#bar"),
+				"org.bitbucket.ceylon.ceylon-compiler:bar:master-SNAPSHOT");
+
+		assertEquals(JitPackUtil.ensureGAV("https://bitbucket.org/ceylon/ceylon-compiler/src/somebranch/#foo:SNAPSHOT"),
+				"org.bitbucket.ceylon.ceylon-compiler:foo:somebranch-SNAPSHOT");
+
+		assertEquals(JitPackUtil.ensureGAV(
+				"https://bitbucket.org/ceylon/ceylon-compiler/commits/9a5e4667af5ae03e036dff1294b81b653be6dffc#foo"),
+				"org.bitbucket.ceylon.ceylon-compiler:foo:9a5e4667af");
+
+	}
+}


### PR DESCRIPTION
You can now add URLs to repos from github.com, gitlab.com and bitbucket.org.

You can use links to the root of the master branch, to any tagged release or to a specific commit and they will be turned into GAV coordinates for JitPack. If the JitPack repo wasn't added by the developer it will be added automatically.