### PR TITLE
Prevent duplicate library on the classpath

### DIFF
--- a/src/main/java/dk/xam/jbang/DependencyUtil.java
+++ b/src/main/java/dk/xam/jbang/DependencyUtil.java
@@ -111,6 +111,7 @@ class DependencyUtil {
 			String classPath = artifacts.stream()
 										.map(it -> it.getAbsolutePath())
 										.map(it -> it.contains(" ") ? '"' + it + '"' : it)
+										.distinct()
 										.collect(Collectors.joining(CP_SEPARATOR));
 
 			if (loggingEnabled) {

--- a/src/test/java/dk/xam/jbang/DependencyResolverTest.java
+++ b/src/test/java/dk/xam/jbang/DependencyResolverTest.java
@@ -125,6 +125,23 @@ class DependencyResolverTest {
 	}
 
 	@Test
+	void testResolveDependenciesNoDuplicates() {
+
+		DependencyUtil dr = new DependencyUtil();
+
+		List<String> deps = Arrays.asList(
+				"org.apache.commons:commons-configuration2:2.7",
+				"org.apache.commons:commons-text:1.8");
+
+		String classpath = dr.resolveDependencies(deps, Collections.emptyList(), false, true);
+
+		// if returns 6 its because some dependencies are multiple times in the
+		// classpath (commons-text-1.8, commons-lang3-3.9)
+		assertEquals(4, classpath.split(Settings.CP_SEPARATOR).length);
+
+	}
+
+	@Test
 	void testResolveNativeDependencies() {
 
 		dk.xam.jbang.Detector detector = new dk.xam.jbang.Detector();


### PR DESCRIPTION
Jbang is adding the same library multiple times on the classpath.

To reproduce:

```java
//usr/bin/env jbang "$0" "$@" ; exit $?

//DEPS org.apache.commons:commons-configuration2:2.7
//DEPS org.apache.commons:commons-text:1.8

import org.apache.commons.configuration2.CompositeConfiguration;
import org.apache.commons.configuration2.SystemConfiguration;
import org.apache.commons.text.WordUtils;

public class commons {

    public static void main(String... args) {
        CompositeConfiguration config = new CompositeConfiguration();
        config.addConfiguration(new SystemConfiguration());

        System.out.println( WordUtils.capitalize("hello world"));
    }
}
```

---

If you have a look at the same project with maven:

```xml
	<dependencies>
		<dependency>
			<groupId>org.apache.commons</groupId>
			<artifactId>commons-configuration2</artifactId>
			<version>2.7</version>
		</dependency>
		<dependency>
			<groupId>org.apache.commons</groupId>
			<artifactId>commons-text</artifactId>
			<version>1.8</version>
		</dependency>
	</dependencies>
```

Maven dependency tree command:

```
mvn dependency:tree -Dverbose
```

Gives you this:

```
+- org.apache.commons:commons-configuration2:jar:2.7:compile
|  +- org.apache.commons:commons-lang3:jar:3.9:compile
|  +- (org.apache.commons:commons-text:jar:1.8:compile - omitted for duplicate)
|  \- commons-logging:commons-logging:jar:1.2:compile
\- org.apache.commons:commons-text:jar:1.8:compile
   \- (org.apache.commons:commons-lang3:jar:3.9:compile - omitted for duplicate)
```

---

The JVM does not care about duplicate entries in the classpath.

If you open the file with Eclipse, you notice an error:

<img width="1013" alt="Eclipse IDE - Build path contains duplicate entry" src="https://user-images.githubusercontent.com/1222165/82363073-a2837d00-9a0d-11ea-8d85-f4ccb8c24601.png">

> Build path contains duplicate entry: '<path-to>/.m2/repository/org/apache/commons/commons-text/1.8/commons-text-1.8.jar' for project 'commons'

Because the generated `.classpath` XML contains the same lib multiple times.

---

This PR is just calling `.distinct()` before concatenating the classpath.