### PR TITLE
Fix java warning

### DIFF
--- a/src/main/java/dk/xam/jbang/DependencyUtil.java
+++ b/src/main/java/dk/xam/jbang/DependencyUtil.java
@@ -63,7 +63,7 @@ class DependencyUtil {
 									.map(JitPackUtil::ensureGAV)
 									.collect(Collectors.toList());
 		// And if we encountered URLs let's make sure the JitPack repo is available
-		if (!depIds.equals(deps) && !repos.contains(REPO_JITPACK)) {
+		if (!depIds.equals(deps) && !repos.stream().anyMatch(r -> REPO_JITPACK.equals(r.getUrl()))) {
 			repos.add(toMavenRepo(ALIAS_JITPACK));
 		}
 


### PR DESCRIPTION
 For the line:

https://github.com/maxandersen/jbang/blob/bbd240c020f2a32830d450df3825348c7a9c4867/src/main/java/dk/xam/jbang/DependencyUtil.java#L66

Eclipse IDE is reporting following warning:

* **Description**: Unlikely argument type `String` for `contains(Object)` on a `Collection<MavenRepo>`
* **Resource**: DependencyUtil.java
* **Path**: /jbang/src/main/java/dk/xam/jbang
* **Location**: line 66
* **Type**: Java Problem

---

I think the static analysis is correct: `!repos.contains(REPO_JITPACK)` is always `true`.

I guess the idea was to not add the `jitpack` twice.

---

This PR contains a fix in this direction.

An alternative could be to remove the `&& !repos.contains(REPO_JITPACK)` part of the `if`.