### PR TITLE
Third party catalog documentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ plugins {
 	id 'maven-publish'
 	id 'io.qameta.allure-report' version '2.12.0'
 	id "io.qameta.allure-adapter-base" version "2.12.0"
-
 }
 
 def allureVersion = '2.29.1'
@@ -160,7 +159,7 @@ dependencies {
 	annotationProcessor 'info.picocli:picocli-codegen:4.7.7'
 	implementation 'io.quarkus.qute:qute-core:1.13.7.Final'
 	implementation 'org.codehaus.plexus:plexus-java:1.2.0'
-	implementation 'com.google.code.gson:gson:2.10.1'
+	implementation 'com.google.code.gson:gson:2.13.2'
 	implementation 'org.jsoup:jsoup:1.17.1'
 	implementation 'org.codejive:java-properties:0.0.7'
 

--- a/docs/modules/ROOT/pages/alias_catalogs.adoc
+++ b/docs/modules/ROOT/pages/alias_catalogs.adoc
@@ -15,7 +15,7 @@ endif::[]
 To avoid remembering long paths and to enable easy launch of jbang scripts there is an `alias` command
 to setup and manage aliases to actual scripts.
 
-NOTE: If your goal is to publish third-party app commands for others, start with xref:third-party-catalogs.adoc[Publishing Third-Party Catalogs]. It is a shorter, app-focused guide for enabling commands like `jbang <cmd>@<your-org>`.
+NOTE: If your goal is to publish app commands for others, start with xref:publishing-app-catalogs.adoc[Publishing App Catalogs]. It is a shorter, app-focused guide for enabling commands like `jbang <cmd>@<your-org>`.
 
 [source,bash]
 ----

--- a/docs/modules/ROOT/pages/alias_catalogs.adoc
+++ b/docs/modules/ROOT/pages/alias_catalogs.adoc
@@ -15,6 +15,8 @@ endif::[]
 To avoid remembering long paths and to enable easy launch of jbang scripts there is an `alias` command
 to setup and manage aliases to actual scripts.
 
+NOTE: If your goal is to publish third-party app commands for others, start with xref:third-party-catalogs.adoc[Publishing Third-Party Catalogs]. It is a shorter, app-focused guide for enabling commands like `jbang <cmd>@<your-org>`.
+
 [source,bash]
 ----
 jbang alias add --name hello https://github.com/jbangdev/jbang-examples/blob/HEAD/examples/helloworld.java

--- a/docs/modules/ROOT/pages/app-installation.adoc
+++ b/docs/modules/ROOT/pages/app-installation.adoc
@@ -311,6 +311,7 @@ ls -la ~/.jbang/bin/
 
 == What's Next?
 
+- **Publish for third parties** → xref:third-party-catalogs.adoc[Publishing Third-Party Catalogs]
 - **Share your tools** → xref:alias_catalogs.adoc[Aliases & Catalogs]
 - **Build complex apps** → xref:organizing.adoc[Organizing Code]
 - **Create native binaries** → xref:native-images.adoc[Native Images]

--- a/docs/modules/ROOT/pages/app-installation.adoc
+++ b/docs/modules/ROOT/pages/app-installation.adoc
@@ -311,7 +311,7 @@ ls -la ~/.jbang/bin/
 
 == What's Next?
 
-- **Publish for third parties** → xref:third-party-catalogs.adoc[Publishing Third-Party Catalogs]
+- **Publish your apps via catalogs** → xref:publishing-app-catalogs.adoc[Publishing App Catalogs]
 - **Share your tools** → xref:alias_catalogs.adoc[Aliases & Catalogs]
 - **Build complex apps** → xref:organizing.adoc[Organizing Code]
 - **Create native binaries** → xref:native-images.adoc[Native Images]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -80,7 +80,7 @@ Explore powerful JBang capabilities:
 * xref:running.adoc[Running & Execution] - Advanced execution options
 * xref:editing.adoc[IDE Integration] - Edit with full IDE support
 * xref:exporting.adoc[Exporting Projects] - Convert to traditional projects
-* xref:third-party-catalogs.adoc[Publishing Third-Party Catalogs] - Let users run your tools as `jbang <cmd>@<your-org>`
+* xref:publishing-app-catalogs.adoc[Publishing App Catalogs] - Let users run your tools as `jbang <cmd>@<your-org>`
 * xref:alias_catalogs.adoc[Aliases & Catalogs] - Share and manage scripts
 
 === ⚙️ Configuration & Tools

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -80,6 +80,7 @@ Explore powerful JBang capabilities:
 * xref:running.adoc[Running & Execution] - Advanced execution options
 * xref:editing.adoc[IDE Integration] - Edit with full IDE support
 * xref:exporting.adoc[Exporting Projects] - Convert to traditional projects
+* xref:third-party-catalogs.adoc[Publishing Third-Party Catalogs] - Let users run your tools as `jbang <cmd>@<your-org>`
 * xref:alias_catalogs.adoc[Aliases & Catalogs] - Share and manage scripts
 
 === ⚙️ Configuration & Tools

--- a/docs/modules/ROOT/pages/publishing-app-catalogs.adoc
+++ b/docs/modules/ROOT/pages/publishing-app-catalogs.adoc
@@ -18,6 +18,9 @@ If you follow this guide, users can run your tools like this:
 ----
 jbang <cmd>@<your-org>
 
+jbang mytool@your-org      # GAV-backed alias
+jbang mytool-lts@your-org  # JAR-backed alias
+
 jbang minecraft-server@microsoft
 jbang camel@redhat-camel
 jbang quarkus@quarkusio

--- a/docs/modules/ROOT/pages/publishing-app-catalogs.adoc
+++ b/docs/modules/ROOT/pages/publishing-app-catalogs.adoc
@@ -1,4 +1,4 @@
-= Publish Third-Party Apps with a JBang Catalog
+= Publish Apps with a JBang Catalog
 :idprefix:
 :idseparator: -
 ifndef::env-github[]

--- a/docs/modules/ROOT/pages/publishing-app-catalogs.adoc
+++ b/docs/modules/ROOT/pages/publishing-app-catalogs.adoc
@@ -18,9 +18,22 @@ If you follow this guide, users can run your tools like this:
 ----
 jbang <cmd>@<your-org>
 
-jbang mytool@your-org      # GAV-backed alias
-jbang mytool-lts@your-org  # JAR-backed alias
+jbang mytool@your-org     
+jbang mytool-lts@your-org
+----
 
+Once you have such a name for you app, users can run it via jbang - but can also install it as a command on their system, using `jbang app install <cmd>@<your-org>`.
+
+[source,bash]
+----
+jbang app install mytool@your-org
+mytool --help
+----
+
+Real-world examples of commands you can run:
+
+[source,bash]
+---
 jbang minecraft-server@microsoft
 jbang camel@redhat-camel
 jbang quarkus@quarkusio
@@ -29,7 +42,9 @@ jbang arthas@alibaba
 
 That is the main value of a catalog: your users get a short, stable command name, and JBang handles how to run the app behind it.
 
-For most teams publishing apps, the best starting point is aliases that target released Maven artifacts (GAVs) or JARs. Script aliases are also supported.
+
+For most teams publishing apps, the best starting point is aliases that target released Maven artifacts (GAVs) or JARs. JBang scripts are also supported, but
+not a requirement.
 
 == Why publish a catalog?
 
@@ -46,7 +61,7 @@ In other words, you publish app names; JBang handles execution details.
 For app catalogs, this is the recommended order:
 
 1. **Maven artifact (GAV)** - best default for versioned releases
-2. **JAR** - great for private/internal distribution or direct downloads
+2. **JAR** - great for private/internal distribution or direct downloads, i.e. github releases
 3. **Script** - fully supported, but usually a secondary publishing path for app catalogs
 
 JBang treats all of these as runnable app targets behind the same alias UX.
@@ -60,15 +75,20 @@ JBang treats all of these as runnable app targets behind the same alias UX.
 |**Org-level catalog** (recommended)
 |Create a repository named `jbang-catalog` under your org/user
 |`jbang <cmd>@<your-org>`
-|Multiple tools and a stable, org-wide command namespace
+|Multiple tools and a stable, shorter, org-wide command namespace
 
 |**Repo-level catalog**
 |Add `jbang-catalog.json` to an existing repository
 |`jbang <cmd>@<your-org>/<repo>`
-|A single product/repository that owns its own commands
+|A single product/repository that owns its own commands, and no org-wide command namespace
 |===
 
 == Option A: org-level catalog repository (recommended)
+
+[TIP]
+====
+Run `jbang init -t jbang-catalog jbang-catalog` to quickly create a catalog repository with renovatebot and GitHub action setup to keep dependencies up to date. Then you can skip to step #3
+====
 
 === 1) Create the catalog repository
 

--- a/docs/modules/ROOT/pages/publishing-app-catalogs.adoc
+++ b/docs/modules/ROOT/pages/publishing-app-catalogs.adoc
@@ -26,15 +26,27 @@ jbang arthas@alibaba
 
 That is the main value of a catalog: your users get a short, stable command name, and JBang handles how to run the app behind it.
 
+For most teams publishing apps, the best starting point is aliases that target released Maven artifacts (GAVs) or JARs. Script aliases are also supported.
+
 == Why publish a catalog?
 
 A catalog gives you:
 
 - A simple command UX (`<cmd>@<your-org>`) for your users
 - One place to curate and describe your app commands
-- Flexibility to point commands at scripts, JARs, or Maven coordinates without changing user-facing command names
+- Flexibility to point commands at Maven coordinates, JARs, or scripts without changing user-facing command names
 
 In other words, you publish app names; JBang handles execution details.
+
+== What should aliases point to?
+
+For app catalogs, this is the recommended order:
+
+1. **Maven artifact (GAV)** - best default for versioned releases
+2. **JAR** - great for private/internal distribution or direct downloads
+3. **Script** - fully supported, but usually a secondary publishing path for app catalogs
+
+JBang treats all of these as runnable app targets behind the same alias UX.
 
 == Where should the catalog live?
 
@@ -68,14 +80,18 @@ Use a minimal app-focused catalog like this:
 {
   "aliases": {
     "mytool": {
-      "script-ref": "https://github.com/your-org/your-repo/blob/main/mytool.java",
-      "description": "Run MyTool from your-org"
+      "script-ref": "com.yourorg:mytool-cli:1.3.0",
+      "description": "Run MyTool CLI from Maven"
+    },
+    "mytool-lts": {
+      "script-ref": "https://downloads.yourorg.com/mytool/mytool-cli-1.2.5.jar",
+      "description": "Run MyTool LTS jar"
     }
   }
 }
 ----
 
-`script-ref` can point to whatever app reference you already publish (script, JAR, or GAV).
+`script-ref` is the target field name and can point to a GAV, JAR, or script. For app catalogs, prefer GAV or JAR targets first.
 
 === 3) Commit and push
 
@@ -109,8 +125,19 @@ Instead of editing JSON by hand, you can add aliases via CLI:
 
 [source,bash]
 ----
+# Preferred: alias pointing to Maven artifact (GAV)
 jbang alias add --file jbang-catalog.json --name mytool \
-  --description "Run MyTool from your-org" \
+  --description "Run MyTool CLI from Maven" \
+  com.yourorg:mytool-cli:1.3.0
+
+# Preferred: alias pointing to JAR
+jbang alias add --file jbang-catalog.json --name mytool-lts \
+  --description "Run MyTool LTS jar" \
+  https://downloads.yourorg.com/mytool/mytool-cli-1.2.5.jar
+
+# Also supported: alias pointing to script
+jbang alias add --file jbang-catalog.json --name mytool-dev \
+  --description "Run MyTool development script" \
   https://github.com/your-org/your-repo/blob/main/mytool.java
 ----
 

--- a/docs/modules/ROOT/pages/publishing-app-catalogs.adoc
+++ b/docs/modules/ROOT/pages/publishing-app-catalogs.adoc
@@ -161,7 +161,7 @@ jbang alias add --file jbang-catalog.json --name mytool-lts \
 # Also supported: alias pointing to script
 jbang alias add --file jbang-catalog.json --name mytool-dev \
   --description "Run MyTool development script" \
-  https://github.com/your-org/your-repo/blob/main/mytool.java
+  mytool.java
 ----
 
 See the full reference for xref:jbang:cli:jbang-alias.adoc[`jbang alias`] and xref:jbang:cli:jbang-catalog.adoc[`jbang catalog`].

--- a/docs/modules/ROOT/pages/third-party-catalogs.adoc
+++ b/docs/modules/ROOT/pages/third-party-catalogs.adoc
@@ -1,0 +1,123 @@
+= Publish Third-Party Apps with a JBang Catalog
+:idprefix:
+:idseparator: -
+ifndef::env-github[]
+:icons: font
+endif::[]
+ifdef::env-github[]
+:caution-caption: :fire:
+:important-caption: :exclamation:
+:note-caption: :paperclip:
+:tip-caption: :bulb:
+:warning-caption: :warning:
+endif::[]
+
+If you follow this guide, users can run your tools like this:
+
+[source,bash]
+----
+jbang <cmd>@<your-org>
+
+jbang minecraft-server@microsoft
+jbang camel@redhat-camel
+jbang quarkus@quarkusio
+jbang arthas@alibaba
+----
+
+That is the main value of a catalog: your users get a short, stable command name, and JBang handles how to run the app behind it.
+
+== Why publish a catalog?
+
+A catalog gives you:
+
+- A simple command UX (`<cmd>@<your-org>`) for your users
+- One place to curate and describe your app commands
+- Flexibility to point commands at scripts, JARs, or Maven coordinates without changing user-facing command names
+
+In other words, you publish app names; JBang handles execution details.
+
+== Where should the catalog live?
+
+[cols="1,2,2,2", options="header"]
+|===
+|Option |Where to put it |How users run it |Best for
+
+|**Org-level catalog** (recommended)
+|Create a repository named `jbang-catalog` under your org/user
+|`jbang <cmd>@<your-org>`
+|Multiple tools and a stable, org-wide command namespace
+
+|**Repo-level catalog**
+|Add `jbang-catalog.json` to an existing repository
+|`jbang <cmd>@<your-org>/<repo>`
+|A single product/repository that owns its own commands
+|===
+
+== Option A: org-level catalog repository (recommended)
+
+=== 1) Create the catalog repository
+
+Create `https://github.com/<your-org>/jbang-catalog` (or equivalent on GitLab/Bitbucket).
+
+=== 2) Add `jbang-catalog.json`
+
+Use a minimal app-focused catalog like this:
+
+[source,json]
+----
+{
+  "aliases": {
+    "mytool": {
+      "script-ref": "https://github.com/your-org/your-repo/blob/main/mytool.java",
+      "description": "Run MyTool from your-org"
+    }
+  }
+}
+----
+
+`script-ref` can point to whatever app reference you already publish (script, JAR, or GAV).
+
+=== 3) Commit and push
+
+Publish the file in the default branch.
+
+=== 4) Validate the user command
+
+[source,bash]
+----
+jbang mytool@your-org
+----
+
+If needed while iterating on changes, test with `--fresh` to bypass caches.
+
+== Option B: catalog file in an existing repository
+
+If you do not want a dedicated `jbang-catalog` repository, add `jbang-catalog.json` to your existing repository.
+
+With a file in the repo root, users can run:
+
+[source,bash]
+----
+jbang mytool@your-org/your-repo
+----
+
+This is often a good fit when command aliases are tightly coupled to one project.
+
+== Managing entries quickly
+
+Instead of editing JSON by hand, you can add aliases via CLI:
+
+[source,bash]
+----
+jbang alias add --file jbang-catalog.json --name mytool \
+  --description "Run MyTool from your-org" \
+  https://github.com/your-org/your-repo/blob/main/mytool.java
+----
+
+See the full reference for xref:jbang:cli:jbang-alias.adoc[`jbang alias`] and xref:jbang:cli:jbang-catalog.adoc[`jbang catalog`].
+
+== Beyond app commands (optional)
+
+Catalogs can also include templates and other entries (for example, jshell-oriented helpers), but most teams should start by publishing clear app aliases first.
+
+For advanced catalog behavior and implicit catalog syntax details, see xref:alias_catalogs.adoc[Aliases & Catalogs] and xref:templates.adoc[Templates].

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -23,6 +23,7 @@
 * Distribution & Deployment
 ** xref:jbang:ROOT:exporting.adoc[Exporting Projects]
 ** xref:jbang:ROOT:app-installation.adoc[Installing as Apps]
+** xref:jbang:ROOT:third-party-catalogs.adoc[Publishing Third-Party Catalogs]
 ** xref:jbang:ROOT:alias_catalogs.adoc[Aliases & Catalogs]
 ** xref:jbang:ROOT:integration.adoc[Build Integration]
 

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -23,7 +23,7 @@
 * Distribution & Deployment
 ** xref:jbang:ROOT:exporting.adoc[Exporting Projects]
 ** xref:jbang:ROOT:app-installation.adoc[Installing as Apps]
-** xref:jbang:ROOT:third-party-catalogs.adoc[Publishing Third-Party Catalogs]
+** xref:jbang:ROOT:publishing-app-catalogs.adoc[Publishing App Catalogs]
 ** xref:jbang:ROOT:alias_catalogs.adoc[Aliases & Catalogs]
 ** xref:jbang:ROOT:integration.adoc[Build Integration]
 

--- a/src/main/java/dev/jbang/net/GroovyManager.java
+++ b/src/main/java/dev/jbang/net/GroovyManager.java
@@ -16,7 +16,7 @@ import dev.jbang.util.UnpackUtil;
 import dev.jbang.util.Util;
 
 public class GroovyManager {
-	public static final String DEFAULT_GROOVY_VERSION = "4.0.27";
+	public static final String DEFAULT_GROOVY_VERSION = "4.0.30";
 
 	public static String resolveInGroovyHome(String cmd, String requestedVersion) {
 		Path groovyHome = getGroovy(requestedVersion);

--- a/src/main/java/dev/jbang/net/KotlinManager.java
+++ b/src/main/java/dev/jbang/net/KotlinManager.java
@@ -15,7 +15,7 @@ import dev.jbang.util.Util;
 
 public class KotlinManager {
 	private static final String KOTLIN_DOWNLOAD_URL = "https://github.com/JetBrains/kotlin/releases/download/v%s/kotlin-compiler-%s.zip";
-	public static final String DEFAULT_KOTLIN_VERSION = "2.1.21";
+	public static final String DEFAULT_KOTLIN_VERSION = "2.3.10";
 
 	public static String resolveInKotlinHome(String cmd, String requestedVersion) {
 		Path kotlinHome = getKotlin(requestedVersion);


### PR DESCRIPTION
This PR introduces a new, simplified documentation guide for third-party developers looking to publish their tools via JBang catalogs.

The primary goal is to provide a clear "elevator pitch" for why and how to enable users to run tools like `jbang <cmd>@<your-org>`, without getting bogged down in JBang jargon.

**Key changes:**
- **New page:** `docs/modules/ROOT/pages/third-party-catalogs.adoc` provides a focused, step-by-step guide for creating org-level or repo-level catalogs, emphasizing application publishing.
- **Improved discoverability:** Updated navigation and existing pages (`alias_catalogs.adoc`, `index.adoc`, `app-installation.adoc`) now direct third-party publishers to this new, simpler entry point.

This change addresses the need for a less dense, value-first explanation for external contributors.

---
<p><a href="https://cursor.com/agents?id=bc-dad3ab5a-ab50-4381-9038-f0a942112daf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dad3ab5a-ab50-4381-9038-f0a942112daf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

